### PR TITLE
fix extract if pytorch dist is an extra

### DIFF
--- a/light_the_torch/_pip/extract.py
+++ b/light_the_torch/_pip/extract.py
@@ -76,6 +76,10 @@ class StopAfterPytorchDistsFoundResolver(PatchedResolverBase):
         if not dists:
             return []
 
+        # If the distribution was found in an extra requirement, pip appends this as
+        # additional information. We remove that here.
+        dists = [dist.split(";")[0] for dist in dists]
+
         if not any(self._pytorch_core_pattern.match(dist) for dist in dists):
             torch = self.PYTORCH_CORE
 


### PR DESCRIPTION
The same was fixed in pmeier/tox-ltt#8.