### PR TITLE
Use latest supported CUDA version to install PyTorch

### DIFF
--- a/light_the_torch/computation_backend.py
+++ b/light_the_torch/computation_backend.py
@@ -2,7 +2,7 @@ import os
 import re
 import subprocess
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, List, Optional
 
 __all__ = [
     "ComputationBackend",
@@ -76,7 +76,8 @@ class CUDABackend(ComputationBackend):
         return f"cu{self.major}{self.minor}"
 
 
-def detect_nvidia_driver() -> str:
+def detect_nvidia_driver() -> Optional[str]:
+    driver: Optional[str]
     try:
         output = subprocess.check_output(
             "nvidia-smi --query-gpu=driver_version --format=csv",
@@ -92,8 +93,8 @@ def detect_nvidia_driver() -> str:
     return driver
 
 
-def get_supported_cuda_version() -> str:
-    def split(version_string):
+def get_supported_cuda_version() -> Optional[str]:
+    def split(version_string: str) -> List[int]:
         return [int(n) for n in version_string.split(".")]
 
     nvidia_driver = detect_nvidia_driver()
@@ -132,8 +133,7 @@ def get_supported_cuda_version() -> str:
 def detect_computation_backend() -> ComputationBackend:
     cuda_version = get_supported_cuda_version()
     if cuda_version is None:
-        backend = CPUBackend()
+        return CPUBackend()
     else:
         major, minor = cuda_version.split(".")
-        backend = CUDABackend(int(major), int(minor))
-    return backend
+        return CUDABackend(int(major), int(minor))

--- a/light_the_torch/computation_backend.py
+++ b/light_the_torch/computation_backend.py
@@ -84,6 +84,9 @@ def detect_nvidia_driver() -> str:
             stderr=subprocess.DEVNULL,
         )
         driver = output.decode("utf-8").splitlines()[-1]
+        pattern = re.compile(r'(\d+\.\d+)')
+        if not pattern.match(driver):
+            driver = None
     except subprocess.CalledProcessError:
         driver = None
     return driver

--- a/light_the_torch/computation_backend.py
+++ b/light_the_torch/computation_backend.py
@@ -84,7 +84,7 @@ def detect_nvidia_driver() -> str:
             stderr=subprocess.DEVNULL,
         )
         driver = output.decode("utf-8").splitlines()[-1]
-        pattern = re.compile(r'(\d+\.\d+)')  # match at least major and minor
+        pattern = re.compile(r"(\d+\.\d+)")  # match at least major and minor
         if not pattern.match(driver):
             driver = None
     except subprocess.CalledProcessError:
@@ -93,9 +93,8 @@ def detect_nvidia_driver() -> str:
 
 
 def get_supported_cuda_version() -> str:
-
     def split(version_string):
-        return [int(n) for n in version_string.split('.')]
+        return [int(n) for n in version_string.split(".")]
 
     nvidia_driver = detect_nvidia_driver()
     if nvidia_driver is None:
@@ -103,30 +102,30 @@ def get_supported_cuda_version() -> str:
 
     nvidia_driver = split(nvidia_driver)
     cuda_version = None
-    if os.name == 'nt':  # windows
+    if os.name == "nt":  # windows
         # Table 3 from https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
-        if nvidia_driver >= split('456.38'):
-            cuda_version = '11.1'
-        elif nvidia_driver >= split('451.22'):
-            cuda_version = '11.0'
-        elif nvidia_driver >= split('441.22'):
-            cuda_version = '10.2'
-        elif nvidia_driver >= split('418.96'):
-            cuda_version = '10.1'
-        elif nvidia_driver >= split('398.26'):
-            cuda_version = '9.2'
+        if nvidia_driver >= split("456.38"):
+            cuda_version = "11.1"
+        elif nvidia_driver >= split("451.22"):
+            cuda_version = "11.0"
+        elif nvidia_driver >= split("441.22"):
+            cuda_version = "10.2"
+        elif nvidia_driver >= split("418.96"):
+            cuda_version = "10.1"
+        elif nvidia_driver >= split("398.26"):
+            cuda_version = "9.2"
     else:  # linux
         # Table 1 from https://docs.nvidia.com/deploy/cuda-compatibility/index.html
-        if nvidia_driver >= split('450.80.02'):
-            cuda_version = '11.1'
-        elif nvidia_driver >= split('450.36.06'):
-            cuda_version = '11.0'
-        elif nvidia_driver >= split('440.33'):
-            cuda_version = '10.2'
-        elif nvidia_driver >= split('418.39'):
-            cuda_version = '10.1'
-        elif nvidia_driver >= split('396.26'):
-            cuda_version = '9.2'
+        if nvidia_driver >= split("450.80.02"):
+            cuda_version = "11.1"
+        elif nvidia_driver >= split("450.36.06"):
+            cuda_version = "11.0"
+        elif nvidia_driver >= split("440.33"):
+            cuda_version = "10.2"
+        elif nvidia_driver >= split("418.39"):
+            cuda_version = "10.1"
+        elif nvidia_driver >= split("396.26"):
+            cuda_version = "9.2"
     return cuda_version
 
 
@@ -135,6 +134,6 @@ def detect_computation_backend() -> ComputationBackend:
     if cuda_version is None:
         backend = CPUBackend()
     else:
-        major, minor = cuda_version.split('.')
+        major, minor = cuda_version.split(".")
         backend = CUDABackend(int(major), int(minor))
     return backend

--- a/light_the_torch/computation_backend.py
+++ b/light_the_torch/computation_backend.py
@@ -84,7 +84,7 @@ def detect_nvidia_driver() -> str:
             stderr=subprocess.DEVNULL,
         )
         driver = output.decode("utf-8").splitlines()[-1]
-        pattern = re.compile(r'(\d+\.\d+)')
+        pattern = re.compile(r'(\d+\.\d+)')  # match at least major and minor
         if not pattern.match(driver):
             driver = None
     except subprocess.CalledProcessError:
@@ -93,34 +93,39 @@ def detect_nvidia_driver() -> str:
 
 
 def get_supported_cuda_version() -> str:
+
+    def split(version_string):
+        return [int(n) for n in version_string.split('.')]
+
     nvidia_driver = detect_nvidia_driver()
     if nvidia_driver is None:
         return None
 
+    nvidia_driver = split(nvidia_driver)
     cuda_version = None
     if os.name == 'nt':  # windows
         # Table 3 from https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
-        if nvidia_driver >= '456.38':
+        if nvidia_driver >= split('456.38'):
             cuda_version = '11.1'
-        elif nvidia_driver >= '451.22':
+        elif nvidia_driver >= split('451.22'):
             cuda_version = '11.0'
-        elif nvidia_driver >= '441.22':
+        elif nvidia_driver >= split('441.22'):
             cuda_version = '10.2'
-        elif nvidia_driver >= '418.96':
+        elif nvidia_driver >= split('418.96'):
             cuda_version = '10.1'
-        elif nvidia_driver >= '398.26':
+        elif nvidia_driver >= split('398.26'):
             cuda_version = '9.2'
     else:  # linux
         # Table 1 from https://docs.nvidia.com/deploy/cuda-compatibility/index.html
-        if nvidia_driver >= '450.80.02':
+        if nvidia_driver >= split('450.80.02'):
             cuda_version = '11.1'
-        elif nvidia_driver >= '450.36.06':
+        elif nvidia_driver >= split('450.36.06'):
             cuda_version = '11.0'
-        elif nvidia_driver >= '440.33':
+        elif nvidia_driver >= split('440.33'):
             cuda_version = '10.2'
-        elif nvidia_driver >= '418.39':
+        elif nvidia_driver >= split('418.39'):
             cuda_version = '10.1'
-        elif nvidia_driver >= '396.26':
+        elif nvidia_driver >= split('396.26'):
             cuda_version = '9.2'
     return cuda_version
 

--- a/tests/unit/test_computation_backend.py
+++ b/tests/unit/test_computation_backend.py
@@ -107,17 +107,18 @@ def test_detect_computation_backend_unknown_release(mocker):
 
 
 def test_detect_computation_backend_cuda(mocker):
-    major = 42
-    minor = 21
+    major = 460
+    minor = 20
+    patch = 30
     mocker.patch(
         "light_the_torch.computation_backend.subprocess.check_output",
-        return_value=f"foo\nbar, release {major}.{minor}, baz".encode("utf-8"),
+        return_value=f"foo\n{major}.{minor}.{patch}".encode("utf-8"),
     )
 
     backend = cb.detect_computation_backend()
     assert isinstance(backend, cb.CUDABackend)
-    assert backend.major == major
-    assert backend.minor == minor
+    assert backend.major == 11
+    assert backend.minor == 1
 
 
 @skip_if_cuda_unavailable


### PR DESCRIPTION
Before these changes, the installed PyTorch version was unnecessarily old for the installed drivers (`430.50`):

```shell
$ ltt install torch                                                                                   
Collecting torch==1.4.0+cu100
  Downloading https://download.pytorch.org/whl/cu100/torch-1.4.0%2Bcu100-cp36-cp36m-linux_x86_64.whl (723.9 MB)
     |██▏                             | 50.2 MB 43.4 MB/s eta 0:00:16^C
```

After these changes, the latest PyTorch compatible with my drivers is correctly used:

```shell
$ ltt install torch                                                                                   
Collecting torch==1.8.1+cu101
  Downloading https://download.pytorch.org/whl/cu101/torch-1.8.1%2Bcu101-cp36-cp36m-linux_x86_64.whl (763.6 MB)
     |██████▊                         | 160.8 MB 36.3 MB/s eta 0:00:17^C
```

Fixes #30.