### PR TITLE
fix version comparison

### DIFF
--- a/light_the_torch/_pip/find.py
+++ b/light_the_torch/_pip/find.py
@@ -251,7 +251,7 @@ class PytorchCandidateEvaluator(CandidateEvaluator):
             cb.ComputationBackend.from_str(
                 candidate.version.local.replace("any", "cpu")
             ),
-            candidate.version.base_version,
+            candidate.version,
         )
 
     def get_applicable_candidates(


### PR DESCRIPTION
`InstallationCandidate.version.base_version` is actually a `str`, so `0.10.0 < 0.9.0`. Not sure why I went with it in the first place, when one of the main reasons for the `Version` class to exist is to handle these comparisons correctly.