### PR TITLE
fix ROCm deselection

### DIFF
--- a/light_the_torch/_patch.py
+++ b/light_the_torch/_patch.py
@@ -244,8 +244,11 @@ def patch_candidate_selection(computation_backends):
         input.candidates = [
             candidate
             for candidate in input.candidates
-            if candidate.version.local is not None
-            and "rocm" not in candidate.version.local
+            if candidate.name not in PYTORCH_DISTRIBUTIONS
+            or (
+                candidate.version.local is not None
+                and "rocm" not in candidate.version.local
+            )
         ]
         return input
 


### PR DESCRIPTION
Fixes overly aggressive candidate deselection from #54. This is what you get for not having proper tests :roll_eyes: 