### PR TITLE
fix incorrect patched distributions template

### DIFF
--- a/.github/incorrect_pytorch_dists_issue_template.md
+++ b/.github/incorrect_pytorch_dists_issue_template.md
@@ -7,5 +7,9 @@ The variable `light_the_torch._patch.PYTORCH_DISTRIBUTIONS` is no longer aligned
 the wheels hosted by PyTorch. Please replace it with
 
 ```py
-{{ env.PYTORCH_DISTRIBUTIONS }}
+PYTORCH_DISTRIBUTIONS = {
+{%- for dist in env.PYTORCH_DISTRIBUTIONS.split(",") %}
+    "{{ dist }}",
+{%- endfor %}
+}
 ```

--- a/.github/incorrect_pytorch_dists_issue_template.md
+++ b/.github/incorrect_pytorch_dists_issue_template.md
@@ -7,9 +7,5 @@ The variable `light_the_torch._patch.PYTORCH_DISTRIBUTIONS` is no longer aligned
 the wheels hosted by PyTorch. Please replace it with
 
 ```py
-PYTORCH_DISTRIBUTIONS = {
-{%- for dist in env.PYTORCH_DISTRIBUTIONS %}
-    "{{ dist }}",
-{%- endfor %}
-}
+{{ env.PYTORCH_DISTRIBUTIONS }}
 ```

--- a/.github/workflows/check-available-pytorch-dists.yml
+++ b/.github/workflows/check-available-pytorch-dists.yml
@@ -26,16 +26,37 @@ jobs:
       - name: Check available PyTorch distributions
         id: pytorch-dists
         run: |
-          PYTORCH_DISTS=$(python scripts/check_available_pytorch_dists.py)
+          PYTORCH_DISTS=`python scripts/check_available_pytorch_dists.py`
           echo "::set-output name=pytorch-dists::${PYTORCH_DISTS}"
           if [[ -n "${PYTORCH_DISTS}" ]]; then { echo "${PYTORCH_DISTS}"; exit 1; }; fi
+
+      - name: Check template
+        if: failure() && github.event_name != 'schedule'
+        shell: python
+        env:
+          PYTORCH_DISTRIBUTIONS: ${{ steps.pytorch-dists.outputs.pytorch-dists }}
+        run: |
+          import os
+          import pathlib
+
+          import jinja2
+
+          path = pathlib.Path.cwd() / ".github"
+          loader = jinja2.FileSystemLoader(searchpath=path)
+          env = jinja2.Environment(loader=loader)
+          template = env.get_template("incorrect_pytorch_dists_issue_template.md")
+
+          print(
+              template.render(
+                  env={"PYTORCH_DISTRIBUTIONS": os.environ["PYTORCH_DISTRIBUTIONS"]},
+              )
+          )
 
       - uses: JasonEtco/create-an-issue@v2.6.0
         if: failure() && github.event_name == 'schedule'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PYTORCH_DISTRIBUTIONS:
-            ${{ toJSON(steps.pytorch-dists.outputs.pytorch-dists) }}
+          PYTORCH_DISTRIBUTIONS: ${{ steps.pytorch-dists.outputs.pytorch-dists }}
         with:
           filename: .github/incorrect_pytorch_dists_issue_template.md
-          update_existing: true
+          update_existing: false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ check-wheel-contents
 # misc
 requests
 beautifulsoup4
+jinja2

--- a/scripts/check_available_pytorch_dists.py
+++ b/scripts/check_available_pytorch_dists.py
@@ -52,10 +52,7 @@ def main():
     extra = PATCHED_PYTORCH_DISTS - available
 
     if missing or extra:
-        print("PYTORCH_DISTRIBUTIONS = {")
-        for dist in sorted(available):
-            print(f'    "{dist}",')
-        print("}")
+        print(",".join(sorted(available)))
 
 
 if __name__ == "__main__":

--- a/scripts/check_available_pytorch_dists.py
+++ b/scripts/check_available_pytorch_dists.py
@@ -15,6 +15,10 @@ EXCLUDED_PYTORCH_DIST = {
     "torch_cuda80",
     "torch_nightly",
     "torchaudio_nightly",
+    # "torchrec_nightly",
+    # "torchrec_nightly_3.7_cu11.whl",
+    # "torchrec_nightly_3.8_cu11.whl",
+    # "torchrec_nightly_3.9_cu11.whl",
 }
 PATCHED_PYTORCH_DISTS = set(PYTORCH_DISTRIBUTIONS)
 
@@ -48,7 +52,10 @@ def main():
     extra = PATCHED_PYTORCH_DISTS - available
 
     if missing or extra:
-        print(json.dumps(sorted(available)))
+        print("PYTORCH_DISTRIBUTIONS = {")
+        for dist in sorted(available):
+            print(f'    "{dist}",')
+        print("}")
 
 
 if __name__ == "__main__":

--- a/scripts/check_available_pytorch_dists.py
+++ b/scripts/check_available_pytorch_dists.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import itertools
-import json
 
 import requests
 from bs4 import BeautifulSoup
@@ -15,10 +14,6 @@ EXCLUDED_PYTORCH_DIST = {
     "torch_cuda80",
     "torch_nightly",
     "torchaudio_nightly",
-    # "torchrec_nightly",
-    # "torchrec_nightly_3.7_cu11.whl",
-    # "torchrec_nightly_3.8_cu11.whl",
-    # "torchrec_nightly_3.9_cu11.whl",
 }
 PATCHED_PYTORCH_DISTS = set(PYTORCH_DISTRIBUTIONS)
 


### PR DESCRIPTION
Instead of checking with `jinja2`, we should check with [`nunjucks`](https://mozilla.github.io/nunjucks/) directly. Given that they try to mirror the functionality, this patch should be sufficient for now.