### PR TITLE
exclude torchrec nightly builds from patching

### DIFF
--- a/scripts/check_available_pytorch_dists.py
+++ b/scripts/check_available_pytorch_dists.py
@@ -14,6 +14,10 @@ EXCLUDED_PYTORCH_DIST = {
     "torch_cuda80",
     "torch_nightly",
     "torchaudio_nightly",
+    "torchrec_nightly",
+    "torchrec_nightly_3.7_cu11.whl",
+    "torchrec_nightly_3.8_cu11.whl",
+    "torchrec_nightly_3.9_cu11.whl",
 }
 PATCHED_PYTORCH_DISTS = set(PYTORCH_DISTRIBUTIONS)
 


### PR DESCRIPTION
Fixes #74. There seems something wrong with their setup. I'm guessing we can revert this in the near future when the index is fixed.