### PR TITLE
exclude torchrec from patched dists

### DIFF
--- a/scripts/check_available_pytorch_dists.py
+++ b/scripts/check_available_pytorch_dists.py
@@ -14,10 +14,13 @@ EXCLUDED_PYTORCH_DIST = {
     "torch_cuda80",
     "torch_nightly",
     "torchaudio_nightly",
+    "torchrec",
+    "torchrec_cpu",
     "torchrec_nightly",
     "torchrec_nightly_3.7_cu11.whl",
     "torchrec_nightly_3.8_cu11.whl",
     "torchrec_nightly_3.9_cu11.whl",
+    "torchrec_nightly_cpu",
 }
 PATCHED_PYTORCH_DISTS = set(PYTORCH_DISTRIBUTIONS)
 


### PR DESCRIPTION
Fixes #77. It was clarified in https://github.com/pytorch/torchrec/issues/334 that they will only use PyPI for now and not the custom PyTorch indices.