### PR TITLE
Update to `pip==22.3`

### DIFF
--- a/light_the_torch/_patch.py
+++ b/light_the_torch/_patch.py
@@ -235,7 +235,9 @@ def get_extra_index_urls(computation_backends, channel):
 @contextlib.contextmanager
 def patch_link_collection(computation_backends, channel):
     search_scope = SearchScope(
-        find_links=[], index_urls=get_extra_index_urls(computation_backends, channel)
+        find_links=[],
+        index_urls=get_extra_index_urls(computation_backends, channel),
+        no_index=False,
     )
 
     @contextlib.contextmanager
@@ -270,7 +272,9 @@ def patch_link_collection(computation_backends, channel):
         # to PyPI.
         _, pypi_file_source = build_source(
             SearchScope(
-                find_links=[], index_urls=["https://pypi.org/simple"]
+                find_links=[],
+                index_urls=["https://pypi.org/simple"],
+                no_index=False,
             ).get_index_urls_locations(input.project_name)[0],
             candidates_from_page=input.candidates_from_page,
             page_validator=input.self.session.is_secure_origin,

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    pip >=22.0, <22.3, != 22.0, != 22.0.1, != 22.0.2
+    pip == 22.3
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
The only thing that changed for us is that `SearchScope` got a new `no_index: bool` parameter. See pypa/pip#11276.

This corresponds to the `--no-index` flag of `pip install`

> `  --no-index                  Ignore package index (only looking at --find-links URLs instead).`

Since we always operate with indices for PyTorch distributions, we can simply hardcode it to `False`.
