### PR TITLE
update deprecated set-output GHA commands

### DIFF
--- a/.github/actions/setup-dev-env/action.yml
+++ b/.github/actions/setup-dev-env/action.yml
@@ -20,7 +20,7 @@ runs:
       run: |
         pip install appdirs
         CACHE_PATH=`python -c "import appdirs; print(appdirs.user_cache_dir('pip', appauthor=False))"`
-        echo "::set-output name=path::$CACHE_PATH"
+        echo "path=${CACHE_PATH}" >> $GITHUB_OUTPUT
 
     - name: Restore pip cache
       uses: actions/cache@v2

--- a/.github/workflows/check-available-pytorch-dists.yml
+++ b/.github/workflows/check-available-pytorch-dists.yml
@@ -27,7 +27,7 @@ jobs:
         id: pytorch-dists
         run: |
           PYTORCH_DISTS=`python scripts/check_available_pytorch_dists.py`
-          echo "::set-output name=pytorch-dists::${PYTORCH_DISTS}"
+          echo "pytorch-dists=${PYTORCH_DISTS}" >> $GITHUB_OUTPUT
           if [[ -n "${PYTORCH_DISTS}" ]]; then { echo "${PYTORCH_DISTS}"; exit 1; }; fi
 
       - name: Check template

--- a/.github/workflows/tests-pip-latest.yml
+++ b/.github/workflows/tests-pip-latest.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           VERSION=`pip show pip | grep Version | sed 's/Version: \(.*\)/\1/'`
           echo "${VERSION}"
-          echo "::set-output name=version::${VERSION}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Upgrade pip and extract version
         id: latest
@@ -45,7 +45,7 @@ jobs:
 
           VERSION=`pip show pip | grep Version | sed 's/Version: \(.*\)/\1/'`
           echo "${VERSION}"
-          echo "::set-output name=version::${VERSION}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Run unit test
         id: tests


### PR DESCRIPTION
Per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

```sh
echo "::set-output name={name}::{value}"
```

is deprecated. Instead, we should use

```sh
echo "{name}={value}" >> $GITHUB_OUTPUT
```