### PR TITLE
fix CI workflow for success with latest pip

### DIFF
--- a/.github/workflows/tests-pip-latest.yml
+++ b/.github/workflows/tests-pip-latest.yml
@@ -77,7 +77,3 @@ jobs:
         with:
           filename: .github/pip_latest_success_issue_template.md
           update_existing: false
-
-      - name: Debug
-        if: steps.tests.outcome == 'success' && matrix.release == 'stable'
-        run: echo "Update pip dependencies"

--- a/.github/workflows/tests-pip-latest.yml
+++ b/.github/workflows/tests-pip-latest.yml
@@ -67,8 +67,8 @@ jobs:
 
       - uses: JasonEtco/create-an-issue@v2.6.0
         if:
-          failure() && github.event_name == 'schedule' && steps.tests.outcome ==
-          'success' && matrix.release == 'stable'
+          github.event_name == 'schedule' && steps.tests.outcome == 'success' &&
+          matrix.release == 'stable'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/tests-pip-latest.yml
+++ b/.github/workflows/tests-pip-latest.yml
@@ -77,3 +77,7 @@ jobs:
         with:
           filename: .github/pip_latest_success_issue_template.md
           update_existing: false
+
+      - name: Debug
+        if: steps.tests.outcome == 'success' && matrix.release == 'stable'
+        run: echo "Update pip dependencies"


### PR DESCRIPTION
Follow-up to #98. This step should create an issue if the test suite passes with a newer `pip`. Thus, `failure() &&` is jsut wrong here:

https://github.com/pmeier/light-the-torch/blob/8e37c9bdd2a7a2016368225594cbf5fcf08f74b7/.github/workflows/tests-pip-latest.yml#L69-L71