### PR TITLE
Add cuda 11.7 and 11.8 to minimum driver version list

### DIFF
--- a/light_the_torch/_cb.py
+++ b/light_the_torch/_cb.py
@@ -150,8 +150,8 @@ def _detect_nvidia_driver_version() -> Optional[Version]:
 # Table 3 from https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 _MINIMUM_DRIVER_VERSIONS = {
     "Linux": {
-        Version("11.7"): Version("510.39.01"),
-        Version("11.6"): Version("510.39.01"),
+        Version("11.7"): Version("515.48.07"),
+        Version("11.6"): Version("510.47.03"),
         Version("11.5"): Version("495.29.05"),
         Version("11.4"): Version("470.82.01"),
         Version("11.3"): Version("465.19.01"),
@@ -167,8 +167,8 @@ _MINIMUM_DRIVER_VERSIONS = {
         Version("8.0"): Version("375.26"),
     },
     "Windows": {
-        Version("11.7"): Version("511.23"),
-        Version("11.6"): Version("511.23"),
+        Version("11.7"): Version("516.31"),
+        Version("11.6"): Version("511.65"),
         Version("11.5"): Version("496.13"),
         Version("11.4"): Version("472.50"),
         Version("11.3"): Version("465.89"),

--- a/light_the_torch/_cb.py
+++ b/light_the_torch/_cb.py
@@ -150,6 +150,7 @@ def _detect_nvidia_driver_version() -> Optional[Version]:
 # Table 3 from https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 _MINIMUM_DRIVER_VERSIONS = {
     "Linux": {
+        Version("11.7"): Version("510.39.01"),
         Version("11.6"): Version("510.39.01"),
         Version("11.5"): Version("495.29.05"),
         Version("11.4"): Version("470.82.01"),
@@ -166,6 +167,7 @@ _MINIMUM_DRIVER_VERSIONS = {
         Version("8.0"): Version("375.26"),
     },
     "Windows": {
+        Version("11.7"): Version("511.23"),
         Version("11.6"): Version("511.23"),
         Version("11.5"): Version("496.13"),
         Version("11.4"): Version("472.50"),

--- a/light_the_torch/_cb.py
+++ b/light_the_torch/_cb.py
@@ -150,6 +150,7 @@ def _detect_nvidia_driver_version() -> Optional[Version]:
 # Table 3 from https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 _MINIMUM_DRIVER_VERSIONS = {
     "Linux": {
+        Version("11.8"): Version("520.61.05"),
         Version("11.7"): Version("515.48.07"),
         Version("11.6"): Version("510.47.03"),
         Version("11.5"): Version("495.29.05"),
@@ -167,6 +168,7 @@ _MINIMUM_DRIVER_VERSIONS = {
         Version("8.0"): Version("375.26"),
     },
     "Windows": {
+        Version("11.8"): Version("520.06"),
         Version("11.7"): Version("516.31"),
         Version("11.6"): Version("511.65"),
         Version("11.5"): Version("496.13"),


### PR DESCRIPTION
According to https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html, the minimum required version >=450.80.02 (linux) and >=452.39 (Windows) but the requirements for 11.6 were already higher, so this higher version requirement were kept for 11.7, too.