### PR TITLE
Add cuda 12.0 to minimum driver version list

### DIFF
--- a/light_the_torch/_cb.py
+++ b/light_the_torch/_cb.py
@@ -150,6 +150,7 @@ def _detect_nvidia_driver_version() -> Optional[Version]:
 # Table 3 from https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 _MINIMUM_DRIVER_VERSIONS = {
     "Linux": {
+        Version("12.0"): Version("525.60.13"),
         Version("11.8"): Version("520.61.05"),
         Version("11.7"): Version("515.48.07"),
         Version("11.6"): Version("510.47.03"),
@@ -168,6 +169,7 @@ _MINIMUM_DRIVER_VERSIONS = {
         Version("8.0"): Version("375.26"),
     },
     "Windows": {
+        Version("12.0"): Version("527.41"),
         Version("11.8"): Version("520.06"),
         Version("11.7"): Version("516.31"),
         Version("11.6"): Version("511.65"),


### PR DESCRIPTION
@pmeier this adds the cuda 12.0 minimum driver version list. Support for cuda 12 is available in latest source builds of torch and will ultimately be available in nightly binaries.