### PR TITLE
remove file requirement from install command

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -34,7 +34,6 @@ def task_install():
     """Installs all development requirements and light-the-torch in development mode"""
     yield dict(
         name="dev",
-        file_dep=[HERE / "requirements-dev.txt"],
         actions=[
             do(
                 "python -m pip install --upgrade --upgrade-strategy=eager",


### PR DESCRIPTION
`pip` already checks whether something is installed or not so we shouldn't require the file to change before installation. I was unable to install a clean env, because doit still had its file cache.