### PR TITLE
add support for pytorch-triton

### DIFF
--- a/scripts/check_pytorch_package_indices.py
+++ b/scripts/check_pytorch_package_indices.py
@@ -16,7 +16,6 @@ from light_the_torch._patch import (
 EXCLUDED_PYTORCH_PACKAGES = {
     "nestedtensor",
     "pytorch_csprng",
-    "pytorch-triton",
     "pytorch-triton-rocm",
     "torch-cuda80",
     "torch-nightly",


### PR DESCRIPTION
`pytorch_triton` sometimes has a commit hash attached to it, e.g.

[pytorch_triton-2.1.0+e6216047b8-cp310-cp310-linux_x86_64.whl](https://download.pytorch.org/whl/nightly/cpu/pytorch_triton-2.1.0%2Be6216047b8-cp310-cp310-linux_x86_64.whl)

It is attached as local specifier (the part after the `+`), which for now was reserved for the computation backend, e.g. `+cpu`. 

Our logic did not account for local specifiers that aren't computation backends, which in turn caused `pytorch-triton` to be deselected. This ultimately lead to https://github.com/pytorch/vision/issues/7923#issuecomment-1701358547.